### PR TITLE
Fix searching of last element in a T*LinkedList

### DIFF
--- a/core/src/main/templates/gnu/trove/list/linked/_E_LinkedList.template
+++ b/core/src/main/templates/gnu/trove/list/linked/_E_LinkedList.template
@@ -44,13 +44,14 @@ import java.util.*;
  * A resizable, double linked list of #e# primitives.
  */
 public class T#E#LinkedList implements T#E#List, Externalizable {
-    #e# no_entry_value;
-    int size;
+    private #e# no_entry_value;
+    private int size;
 
-    T#E#Link head = null;
-    T#E#Link tail = head;
+    private T#E#Link head = null;
+    private T#E#Link tail = head;
 
     public T#E#LinkedList() {
+    	this( Constants.DEFAULT_#EC#_NO_ENTRY_VALUE );
     }
 
     public T#E#LinkedList(#e# no_entry_value) {
@@ -764,12 +765,16 @@ public class T#E#LinkedList implements T#E#List, Externalizable {
     /** {@inheritDoc} */
     public int indexOf(int offset, #e# value) {
         int count = offset;
-        for (T#E#Link l = getLinkAt(offset); got(l.getNext()); l = l.getNext()) {
+
+        T#E#Link l;
+        for (l = getLinkAt(offset); got(l.getNext()); l = l.getNext()) {
             if (l.getValue() == value)
                 return count;
 
             count++;
         }
+
+        if ( l != null && l.getValue() == value ) return count;
 
         return -1;
     }

--- a/core/src/test/java/gnu/trove/list/linked/TLinkedListTest.java
+++ b/core/src/test/java/gnu/trove/list/linked/TLinkedListTest.java
@@ -1114,6 +1114,21 @@ public class TLinkedListTest extends TestCase {
 	}
 
 
+	// Test for https://bitbucket.org/robeden/trove/issue/16/
+	public void testLastIndexOf() {
+		TIntLinkedList list = new TIntLinkedList();
+		list.add( 0 );
+		list.add( 1 );
+		list.add( 2 );
+		list.add( 3 );
+
+		assertEquals( list.indexOf( 0 ), 0 );
+		assertEquals( list.indexOf( 1 ), 1 );
+		assertEquals( list.indexOf( 2 ), 2 );
+		assertEquals( list.indexOf( 3 ), 3 );
+	}
+
+
     static class Data implements TLinkable<Data> {
 
         protected int _val;


### PR DESCRIPTION
 The final node was being ignored.

Pull in changes from the original commit:
https://github.com/slimjars/trove4j-history/commit/1be860e04104aba441e9edd542d8b6dd6d697ba3