### PR TITLE
Improve equality implementation of T*LinkedList and T*ArrayList

### DIFF
--- a/core/src/main/templates/gnu/trove/list/array/_E_ArrayList.template
+++ b/core/src/main/templates/gnu/trove/list/array/_E_ArrayList.template
@@ -743,17 +743,18 @@ public class T#E#ArrayList implements T#E#List, Externalizable {
         if ( other instanceof T#E#ArrayList ) {
             T#E#ArrayList that = ( T#E#ArrayList )other;
             if ( that.size() != this.size() ) return false;
-            else {
-                for ( int i = _pos; i-- > 0; ) {
-                    if ( this._data[ i ] != that._data[ i ] ) {
-                        return false;
-                    }
+
+            for ( int i = _pos; i-- > 0; ) {
+                if ( this._data[ i ] != that._data[ i ] ) {
+                    return false;
                 }
-                return true;
             }
+            return true;
         }
         else {
             T#E#List that = ( T#E#List )other;
+            if ( that.size() != this.size() ) return false;
+
             for( int i = 0; i < _pos; i++ ) {
                 if ( this._data[ i ] != that.get( i ) ) {
                     return false;

--- a/core/src/main/templates/gnu/trove/list/linked/_E_LinkedList.template
+++ b/core/src/main/templates/gnu/trove/list/linked/_E_LinkedList.template
@@ -1009,38 +1009,37 @@ public class T#E#LinkedList implements T#E#List, Externalizable {
         return ref == null;
     }
 
+
+    // comparing
+
+    /** {@inheritDoc} */
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        T#E#LinkedList that = (T#E#LinkedList) o;
-
-        if (no_entry_value != that.no_entry_value) return false;
-        if (size != that.size) return false;
-
-        T#E#Iterator iterator = iterator();
-        T#E#Iterator thatIterator = that.iterator();
-        while (iterator.hasNext()) {
-            if (!thatIterator.hasNext())
-                return false;
-
-            if (iterator.next() != thatIterator.next())
-                return false;
+    public boolean equals( Object other ) {
+        if ( other == this ) {
+            return true;
         }
+        if ( !( other instanceof T#E#List ) ) return false;
 
+        T#E#List that = ( T#E#List )other;
+        if ( size() != that.size() ) return false;
+
+        for( int i = 0; i < size(); i++ ) {
+            if ( get( i ) != that.get( i ) ) {
+                return false;
+            }
+        }
         return true;
     }
 
+
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        int result = HashFunctions.hash(no_entry_value);
-        result = 31 * result + size;
-        for (T#E#Iterator iterator = iterator(); iterator.hasNext();) {
-            result = 31 * result + HashFunctions.hash(iterator.next());
+        int h = 0;
+        for ( int i = size(); i-- > 0; ) {
+            h += HashFunctions.hash( get( i ) );
         }
-
-        return result;
+        return h;
     }
 
     @Override

--- a/core/src/test/java/gnu/trove/list/array/TArrayListTest.java
+++ b/core/src/test/java/gnu/trove/list/array/TArrayListTest.java
@@ -21,6 +21,9 @@
 package gnu.trove.list.array;
 
 import gnu.trove.list.TIntList;
+import gnu.trove.list.TLongList;
+import gnu.trove.lists.TUnmodifiableIntLists;
+import gnu.trove.lists.TUnmodifiableLongLists;
 import junit.framework.TestCase;
 
 import java.io.ByteArrayInputStream;
@@ -300,4 +303,54 @@ public class TArrayListTest extends TestCase {
         int[] a = new int[]{1, 2, 3};
         i.retainAll(a);
     }
+
+	public void testIntUnmodifiableEquality() {
+		TIntList list1 = new TIntArrayList();
+		TIntList list2 = new TIntArrayList();
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableIntLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ),
+			TUnmodifiableIntLists.wrap( list2 ) );
+
+		list1.add( 1 );
+		list1.add( 2 );
+		list1.add( 3 );
+
+		list2.add( 1 );
+		list2.add( 2 );
+		list2.add( 3 );
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableIntLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ),
+			TUnmodifiableIntLists.wrap( list2 ) );
+	}
+
+	public void testLongUnmodifiableEquality() {
+		TLongList list1 = new TLongArrayList();
+		TLongList list2 = new TLongArrayList();
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableLongLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ),
+			TUnmodifiableLongLists.wrap( list2 ) );
+
+		list1.add( 1 );
+		list1.add( 2 );
+		list1.add( 3 );
+
+		list2.add( 1 );
+		list2.add( 2 );
+		list2.add( 3 );
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableLongLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ),
+			TUnmodifiableLongLists.wrap( list2 ) );
+	}
 }

--- a/core/src/test/java/gnu/trove/list/linked/TLinkedListTest.java
+++ b/core/src/test/java/gnu/trove/list/linked/TLinkedListTest.java
@@ -22,6 +22,9 @@ package gnu.trove.list.linked;
 
 import gnu.trove.list.TIntList;
 import gnu.trove.list.TLinkable;
+import gnu.trove.list.TLongList;
+import gnu.trove.lists.TUnmodifiableIntLists;
+import gnu.trove.lists.TUnmodifiableLongLists;
 import gnu.trove.procedure.TObjectProcedure;
 import junit.framework.TestCase;
 
@@ -1126,6 +1129,56 @@ public class TLinkedListTest extends TestCase {
 		assertEquals( list.indexOf( 1 ), 1 );
 		assertEquals( list.indexOf( 2 ), 2 );
 		assertEquals( list.indexOf( 3 ), 3 );
+	}
+
+	public void testIntUnmodifiableEquality() {
+		TIntList list1 = new TIntLinkedList();
+		TIntList list2 = new TIntLinkedList();
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableIntLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ),
+				TUnmodifiableIntLists.wrap( list2 ) );
+
+		list1.add( 1 );
+		list1.add( 2 );
+		list1.add( 3 );
+
+		list2.add( 1 );
+		list2.add( 2 );
+		list2.add( 3 );
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableIntLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableIntLists.wrap( list1 ),
+			TUnmodifiableIntLists.wrap( list2 ) );
+	}
+
+	public void testLongUnmodifiableEquality() {
+		TLongList list1 = new TLongLinkedList();
+		TLongList list2 = new TLongLinkedList();
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableLongLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ),
+			TUnmodifiableLongLists.wrap( list2 ) );
+
+		list1.add( 1 );
+		list1.add( 2 );
+		list1.add( 3 );
+
+		list2.add( 1 );
+		list2.add( 2 );
+		list2.add( 3 );
+
+		assertEquals( list1, list2 );
+		assertEquals( list1, TUnmodifiableLongLists.wrap( list2 ) );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ), list2 );
+		assertEquals( TUnmodifiableLongLists.wrap( list1 ),
+			TUnmodifiableLongLists.wrap( list2 ) );
 	}
 
 


### PR DESCRIPTION
Pull in changes from this original commit: https://github.com/slimjars/trove4j-history/commit/981871f74926e1506871ae747a60abe8abd66199, which have been addressed in https://bitbucket.org/trove4j/trove/issues/8 (and should have ended up in #2)

Correction to equals() for T*LinkedList. Minor optimization to equals() for T*ArrayList.